### PR TITLE
Support for specifying S3 partition size and HDFS block size and readable error messages for assertion failures.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Usage
 
     export AWS_ACCESS_KEY=...
     export AWS_SECRET_KEY=...
-    spark-submit spark-s3-downloader-VERSION.jar s3://BUCKET/KEY hdfs://HOST[:PORT]/path
+    spark-submit spark-s3-downloader-VERSION.jar s3://BUCKET/KEY hdfs://HOST[:PORT]/path [--s3-part-size <value>] [--hdfs-block-size <value>]
 
 Build
 =====
@@ -49,7 +49,6 @@ Caveats
 * Alpha-quality
 * Uses Spark, not Yarn/MapReduce
 * Lack of unit tests
-* Hard-coded task and block size of 64MB
 * Destination must be a full ``hdfs://`` URL, the ``fs.default.name``
   property is ignored
 * On failure, temporary files may be left around

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>commons-io</artifactId>
             <version>2.4</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.scopt</groupId>
+            <artifactId>scopt_2.10</artifactId>
+            <version>3.3.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Resolves Issue #1 by giving users the ability to specify the size of S3 partitions and HDFS blocks. The parameters are "--s3-part-size" and "--hdfs-block-size". Default values for both are 64 Mb. Part size must be a multiple of block size.

Also resolves Issue #2 by adding human-readable error messages for assertion failures.
