### PR TITLE
Allow Spark/Hadoop version to be set during build.

### DIFF
--- a/conductor/pom.xml
+++ b/conductor/pom.xml
@@ -9,12 +9,59 @@
         <version>0.5-SNAPSHOT</version>
     </parent>
 
+    <properties>
+      <spark.version>1.4.1</spark.version>
+      <hadoop.version>2.2.0</hadoop.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.10</artifactId>
-            <version>1.2.1</version>
+            <version>${spark.version}</version>
             <scope>provided</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-client</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-mapreduce</artifactId>
+              </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+          <version>${hadoop.version}</version>
+          <scope>provided</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>asm</groupId>
+              <artifactId>asm</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.jboss.netty</groupId>
+              <artifactId>netty</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.codehaus.jackson</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.sonatype.sisu.inject</groupId>
+              <artifactId>*</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>javax.servlet</groupId>
+              <artifactId>servlet-api</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.google.guava</groupId>
+              <artifactId>guava</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
I have modified the packaging so that Spark and Hadoop versions are parametrized. With this, the versions can be set on the Maven command line during build, e.g.:

```
mvn package -Dhadoop.version=2.6.2 -Dspark.version=1.5.2
```

This resolves an issue we were having in the toil/ADAM pipeline, since the version of HDFS we were using did not match the version of HDFS that Conductor was built against.

To be honest, I'm not 100% sure that it is an issue, but it is probably preferable to make this fix since this gives better control over the HDFS version.
