### PR TITLE
Adding YARN S3 credentials steps to README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,14 @@ sizes; if it points to a directory, each part will correspond to a file in the
 directory. Concatenation only works in downloader if all of the parts except
 for the last one are equal-sized and multiples of the specified block size.
 
+If running Spark-on-YARN, you can pass the AWS access/secret keys by passing
+the following config flags to `spark-submit`:
+
+```
+--conf  spark.yarn.appMasterEnv.AWS_ACCESS_KEY=...
+--conf  spark.yarn.appMasterEnv.AWS_SECRET_KEY=...
+```
+
 Tests
 =====
 ::


### PR DESCRIPTION
Small documentation addition. I was trying to remember how to do this today, and had to dig through a ton of email. I figured that someone else will eventually need to do it, thus it is useful to have in the README.
