### PR TITLE
Pin AWS SDK to version 1.10.32 to prevent transitive dependency errors at runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spark.version>1.2.1</spark.version>
+        <spark.version>1.6.2</spark.version>
         <hadoop.version>2.6.0</hadoop.version>
     </properties>
 
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-s3</artifactId>
-                <version>1.9.25</version>
+                <version>1.10.32</version> <!-- pinned to version 1.10.32 to prevent transitive dependency errors at runtime -->
             </dependency>
             <dependency>
                 <groupId>com.github.scala-incubator.io</groupId>
@@ -57,12 +57,12 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
             </dependency>
             <dependency>
                 <groupId>com.github.scopt</groupId>
                 <artifactId>scopt_2.10</artifactId>
-                <version>3.3.0</version>
+                <version>3.5.0</version>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>
@@ -72,7 +72,7 @@
             <dependency>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest_2.10</artifactId>
-                <version>2.2.4</version>
+                <version>2.2.6</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -89,10 +89,10 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>3.1.6</version>
+                    <version>3.2.2</version>
                     <configuration>
                         <scalaCompatVersion>2.10</scalaCompatVersion>
-                        <scalaVersion>2.10</scalaVersion>
+                        <scalaVersion>2.10.6</scalaVersion>
                     </configuration>
                     <executions>
                         <execution>
@@ -106,7 +106,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>3.0.0</version>
                     <executions>
                         <execution>
                             <phase>package</phase>
@@ -148,7 +148,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.19.1</version>
                     <configuration>
                         <skipTests>true</skipTests>
                     </configuration>


### PR DESCRIPTION
Build from git HEAD does not work on Spark 1.6.2 provided by cgcloud spark-box due to transitive dependency errors at runtime (will create an issue once I find the stack trace I've since misplaced).

Updating the Spark compile scope dependency version to 1.6.2 and pinning the AWS SDK to version 1.10.32 works for me.

@fnothaft 